### PR TITLE
Add Docker image setup for full-stack deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+__pycache__
+*.pyc
+client/node_modules
+client/dist
+images
+mercari_listings.json
+clip_embeddings.npz
+clip_embeddings.npy
+.env
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+# Frontend build stage
+FROM node:18 AS frontend-builder
+WORKDIR /frontend
+
+COPY client/package*.json ./
+RUN npm ci
+
+COPY client/ ./
+RUN npm run build
+
+# Final runtime image
+FROM mcr.microsoft.com/playwright/python:v1.41.1-jammy
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cpu \
+    && pip install --no-cache-dir -r requirements.txt \
+    && playwright install --with-deps chromium
+
+COPY docker-entrypoint.sh ./
+RUN chmod +x docker-entrypoint.sh
+
+COPY --from=frontend-builder /frontend/dist ./client_dist
+COPY . ./
+
+ENV FLASK_RUN_HOST=0.0.0.0
+ENV FLASK_RUN_PORT=5000
+ENV FLASK_ENV=production
+
+EXPOSE 5000
+
+ENTRYPOINT ["./docker-entrypoint.sh"]
+CMD ["python", "app.py"]

--- a/app.py
+++ b/app.py
@@ -1,12 +1,16 @@
 from flask import Flask, request, jsonify
 from flask_cors import CORS
 import os
+from pathlib import Path
 from find_similar_items import find_similar_items
 from flask import send_from_directory
 
-app = Flask(__name__)
+BASE_DIR = Path(__file__).resolve().parent
+FRONTEND_DIST = BASE_DIR / "client_dist"
+
+app = Flask(__name__, static_folder=str(FRONTEND_DIST), static_url_path="/")
 # allow requests from React
-CORS(app)  
+CORS(app)
 
 @app.route("/api/search", methods=["POST"])
 def search():
@@ -27,5 +31,26 @@ def search():
 def serve_image(filename):
     return send_from_directory("images", filename)
 
+
+@app.route("/", defaults={"path": ""})
+@app.route("/<path:path>")
+def serve_frontend(path):
+    """Serve the built frontend if it exists."""
+    if not FRONTEND_DIST.exists():
+        return "Frontend build not found. Run 'npm run build' inside client/.", 404
+
+    requested = FRONTEND_DIST / path
+    if path and requested.exists():
+        return send_from_directory(str(FRONTEND_DIST), path)
+
+    index_file = FRONTEND_DIST / "index.html"
+    if index_file.exists():
+        return send_from_directory(str(FRONTEND_DIST), "index.html")
+
+    return "Frontend build missing index.html", 404
+
 if __name__ == "__main__":
-    app.run(debug=True)
+    host = os.environ.get("FLASK_RUN_HOST", "0.0.0.0")
+    port = int(os.environ.get("FLASK_RUN_PORT", "5000"))
+    debug = os.environ.get("FLASK_DEBUG") == "1"
+    app.run(host=host, port=port, debug=debug)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+RUN_PIPELINE_MODE="${RUN_PIPELINE:-auto}"
+DATA_READY=true
+
+if [ ! -f "mercari_listings.json" ] || [ ! -f "clip_embeddings.npz" ]; then
+  DATA_READY=false
+fi
+
+if [ "${RUN_PIPELINE_MODE}" = "always" ]; then
+  echo "RUN_PIPELINE=always - refreshing Mercari data before launch"
+  python run_pipeline.py
+elif [ "${RUN_PIPELINE_MODE}" = "auto" ]; then
+  if [ "${DATA_READY}" = "false" ]; then
+    echo "Mercari dataset missing - running pipeline before launch"
+    python run_pipeline.py
+  else
+    echo "Found existing dataset artifacts - skipping pipeline"
+  fi
+else
+  echo "RUN_PIPELINE=${RUN_PIPELINE_MODE} - skipping data pipeline"
+fi
+
+exec "$@"

--- a/readme.md
+++ b/readme.md
@@ -12,3 +12,41 @@
 - Backend powered by Flask, Python, and Playwright
 
 ![App Preview](./preview.png)
+
+## Docker quickstart
+
+You can ship the entire stack as a single Docker image that builds the React frontend, installs the Python/Playwright dependencies, and optionally refreshes the Mercari dataset on startup.
+
+1. **Build the image**
+   ```bash
+   docker build -t mercari-visual-search .
+   ```
+
+2. **Run the container**
+   ```bash
+   docker run -p 5000:5000 mercari-visual-search
+   ```
+   On first launch the container checks for `mercari_listings.json` and `clip_embeddings.npz`. If they are missing it automatically runs `python run_pipeline.py` inside the container to scrape listings, download images, and regenerate CLIP embeddings before starting the Flask server.
+
+3. **Open the app**
+   Visit [http://localhost:5000](http://localhost:5000) in your browser. The Flask backend serves both the API and the built frontend.
+
+### Optional runtime controls
+
+- Skip the pipeline on startup (useful when you mount pre-generated artifacts):
+  ```bash
+  docker run -p 5000:5000 \
+    -e RUN_PIPELINE=never \
+    -v $(pwd)/mercari_listings.json:/app/mercari_listings.json \
+    -v $(pwd)/clip_embeddings.npz:/app/clip_embeddings.npz \
+    -v $(pwd)/images:/app/images \
+    mercari-visual-search
+  ```
+  Ensure the mounted files/directories exist on the host before starting the container.
+
+- Force a fresh scrape every time:
+  ```bash
+  docker run -p 5000:5000 -e RUN_PIPELINE=always mercari-visual-search
+  ```
+
+The container exposes port `5000` and respects the `FLASK_RUN_HOST`, `FLASK_RUN_PORT`, and `FLASK_DEBUG` environment variables if you need to override them.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+flask
+flask-cors
+numpy
+Pillow
+requests
+beautifulsoup4
+playwright
+ftfy
+regex
+tqdm
+git+https://github.com/openai/CLIP.git


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile that builds the React frontend and packages the Flask backend with Playwright
- include an entrypoint that conditionally runs the Mercari data pipeline and document docker usage in the README
- capture Python dependencies and ignore bulky folders for leaner docker build contexts

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68db5dfd2b1c832ea8c8f43291371b14